### PR TITLE
Resolves issues with secure cookies, blocking Shopify password form

### DIFF
--- a/documentation/content/settings/browsersync.md
+++ b/documentation/content/settings/browsersync.md
@@ -49,3 +49,29 @@ Take a read of the [Local Development](/docs/local-development/) section to bett
   }
 }
 ```
+
+#### bs.https
+
+This simply proxy's BrowserSync's [https](https://browsersync.io/docs/options#option-https) option but it is powerful since it allows you to add in your own SSL certificates so you can remove the nasty "Your connection to this site is not secure" browser prompt.
+
+```js
+{
+  'bs.https': true
+}
+```
+
+Example configuration in a kit.config.js file is below. This would allow different developers to use different certificate pairs, or opt-out of using custom certificates.
+
+```js
+{
+  "bs.https": process.env.LOCALHOST_CERT ? {
+    cert: process.env.LOCALHOST_CERT,
+    key: process.env.LOCALHOST_KEY
+  } : true,
+}
+```
+
+See details on how to get setup with this here:
+
+- https://ryanparman.com/posts/2019/how-to-create-local-tls-certificates-for-development-on-macos/
+- https://blogjunkie.net/2017/04/enable-https-localhost-browsersync/

--- a/packages/configure/src/defaults/browserSync.js
+++ b/packages/configure/src/defaults/browserSync.js
@@ -9,6 +9,7 @@ module.exports = {
       settings['theme']
     }`
   },
+  'bs.https': true,
   // Sets the location that BrowserSync places the live reload snippet
   'bs.snippetPlacement'(settings) {
     return {

--- a/packages/webpacker/src/cookie-handling.js
+++ b/packages/webpacker/src/cookie-handling.js
@@ -1,0 +1,60 @@
+/**
+ * This file is a patch for core BrowserSync code that we've had to
+ * rewrite to resolve issues with secure cookies. This code is
+ * resolves the immediate issue until a fix is merged into BrowserSync.
+ * @see: https://github.com/BrowserSync/browser-sync/pull/1964
+ * @see: https://github.com/BrowserSync/browser-sync/blob/master/packages/browser-sync/lib/server/proxy-utils.js#L122
+ */
+
+/**
+ * Remove 'domain' from any cookies
+ * @param {Object} res
+ */
+function checkCookies(res) {
+  if (typeof res.headers['set-cookie'] !== 'undefined') {
+    res.headers['set-cookie'] = res.headers['set-cookie'].map(function (item) {
+      return rewriteCookies(item)
+    })
+  }
+}
+
+/**
+ * Remove the domain from any cookies.
+ * @param rawCookie
+ * @returns {string}
+ */
+function rewriteCookies(rawCookie) {
+  var objCookie = (function () {
+    // simple parse function (does not remove quotes)
+    var obj = {}
+    var pairs = rawCookie.split(/; */)
+    pairs.forEach(function (pair) {
+      var eqIndex = pair.indexOf('=')
+      // skip things that don't look like key=value
+      if (eqIndex < 0) {
+        return
+      }
+      var key = pair.substr(0, eqIndex).trim()
+      obj[key] = pair.substr(eqIndex + 1, pair.length).trim()
+    })
+    return obj
+  })()
+  var pairs = Object.keys(objCookie)
+    .filter(function (item) {
+      return item.toLowerCase() !== 'domain'
+    })
+    .map(function (key) {
+      return key + '=' + objCookie[key]
+    })
+  if (rawCookie.match(/httponly/i)) {
+    pairs.push('HttpOnly')
+  }
+  if (rawCookie.match(/secure/i)) {
+    pairs.push('secure')
+  }
+  return pairs.join('; ')
+}
+
+module.exports = {
+  checkCookies
+}

--- a/packages/webpacker/src/setUpProxy.js
+++ b/packages/webpacker/src/setUpProxy.js
@@ -3,6 +3,7 @@ const WHM = require('webpack-hot-middleware')
 const browserSync = require('browser-sync').create()
 const wait = require('w2t')
 const { action } = require('@halfhelix/terminal-kit')
+const { checkCookies } = require('./cookie-handling')
 
 function isLocalhost(string) {
   return /localhost/.test(string)
@@ -24,6 +25,10 @@ function makeConfig(webpack, settings, watchCallback) {
     online: settings['bs.online'],
     proxy: {
       target: settings['bs.target'](settings),
+      cookies: {
+        stripDomain: false,
+        proxyRes: [checkCookies]
+      },
       middleware: [wdm]
     },
     open: settings['bs.open']
@@ -32,7 +37,7 @@ function makeConfig(webpack, settings, watchCallback) {
         : 'external'
       : false,
     host: settings['bs.local'],
-    https: true,
+    https: settings['bs.https'],
     notify: false,
     snippetOptions: {
       rule: settings['bs.snippetPlacement'](settings),


### PR DESCRIPTION
This PR resolves a critical issue with BrowserSync's handling of SameSite=None/Secure cookies. Hopefully we'll get a fix directly into BrowserSync but in the meantime this should resolve the issue. The issue stopped allowing the Shopify password form from being able to be submitted since the returning `storefront_digest={hash}` SameSite=None/Secure cookie was getting invalidated and thus breaking Shopify's ability to establish a session in the response.

A PR has been logged with BrowserSync here: https://github.com/BrowserSync/browser-sync/pull/1964. The BrowserSync function of note is: https://github.com/BrowserSync/browser-sync/blob/master/packages/browser-sync/lib/server/proxy-utils.js#L122

In my diagnosis of the issue I also added support for self certified TLS certificates so that the browser won't prompt that localhost is not secure. In order to use this functionality the following tutorials can be followed:
- https://ryanparman.com/posts/2019/how-to-create-local-tls-certificates-for-development-on-macos/
- https://blogjunkie.net/2017/04/enable-https-localhost-browsersync/