### PR TITLE
check for js or css filetype

### DIFF
--- a/packages/shopify-kit/services/tokenization/index.js
+++ b/packages/shopify-kit/services/tokenization/index.js
@@ -58,7 +58,7 @@ function getBase(path, file) {
     base = 'locales'
   } else if (/layout\//.test(path)) {
     base = 'layout'
-  } else if (/(?:s?css|js)[.]liquid$/.test(file)) {
+  } else if (/[.](?:s?css|js)[.]liquid$/.test(file)) {
     base = 'assets'
   } else if (!/[.]liquid$/.test(file)) {
     base = 'assets'


### PR DESCRIPTION
Currently if a file in snippets has `-js.liquid` or `-css.liquid` in the filename it gets moved to assets instead of remaining in snippets which is causing issues on Rothy's